### PR TITLE
Remove pagination placeholders from bottom of Recipe items page

### DIFF
--- a/recipeItems.html
+++ b/recipeItems.html
@@ -43,7 +43,7 @@
             <div class="recipeCards row row-cols-2 row-cols-lg-3 g-2 g-lg-3"></div>
         </div>
     </main>
-
+<!-- 
     <nav aria-label="Search results pages">
         <ul class="pagination pagination-lg justify-content-center pt-3">
           <li class="page-item active" aria-current="page">
@@ -51,7 +51,7 @@
           </li>
           <li class="page-item"><a class="page-link" href="#">2</a></li>
         </ul>
-      </nav>
+      </nav> -->
 
     <footer class="footer">
         <div style="display: flex; align-items: center; justify-content: space-between; padding: 15px; margin-top: 5px;"> 


### PR DESCRIPTION
- Commented out pagination in html (in case we want to use it later)
- Kept limit of 9 recipes displaying on Recipe items page
